### PR TITLE
Fix type juggling

### DIFF
--- a/src/Response.php
+++ b/src/Response.php
@@ -74,7 +74,7 @@ class Response
                 continue;
             }
 
-            if ($key == 'jsonrpc') {
+            if ('jsonrpc' == $key) {
                 $this->setVersion($value);
                 continue;
             }


### PR DESCRIPTION
If $key is int with value 0, we have true result for condition. It's wrong.
