### PR TITLE
default headers will not override those set by user anymore

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -117,11 +117,16 @@ class Client implements ServerClient
             $this->httpClient->setUri($this->serverAddress);
         }
 
+        // set default Accept and Content-Type headers unless already set
         $headers = $httpRequest->getHeaders();
-        $headers->addHeaders([
-            'Content-Type' => 'application/json',
-            'Accept'       => 'application/json',
-        ]);
+        $headersToAdd = [];
+        if(!$headers->has('Content-Type')) {
+            $headersToAdd['Content-Type'] = 'application/json-rpc';
+        }
+        if (!$headers->has('Accept')) {
+            $headersToAdd['Accept'] = 'application/json-rpc';
+        }
+        $headers->addHeaders($headersToAdd);
 
         if (! $headers->get('User-Agent')) {
             $headers->addHeaderLine('User-Agent', 'Zend_Json_Server_Client');
@@ -188,4 +193,5 @@ class Client implements ServerClient
             ->setId(++$this->id);
         return $request;
     }
+
 }

--- a/src/Client.php
+++ b/src/Client.php
@@ -120,7 +120,7 @@ class Client implements ServerClient
         // set default Accept and Content-Type headers unless already set
         $headers = $httpRequest->getHeaders();
         $headersToAdd = [];
-        if(!$headers->has('Content-Type')) {
+        if (!$headers->has('Content-Type')) {
             $headersToAdd['Content-Type'] = 'application/json-rpc';
         }
         if (!$headers->has('Accept')) {
@@ -193,5 +193,4 @@ class Client implements ServerClient
             ->setId(++$this->id);
         return $request;
     }
-
 }


### PR DESCRIPTION
was unable to change default headers on json rpc client so i have submitted this PR.

also changed default headers for content type and accept to more appropriate "application/json-rpc" as per specification [http://www.jsonrpc.org/historical/json-rpc-over-http.html#http-header](http://www.jsonrpc.org/historical/json-rpc-over-http.html#http-header)

> Content-Type SHOULD be 'application/json-rpc' but MAY be 'application/json' or 'application/jsonrequest'
> 
> The Accept MUST be specified and SHOULD read 'application/json-rpc' but MAY be 'application/json' or 'application/jsonrequest'.
